### PR TITLE
Implement ZIP code deidentification script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+*.egg-info/
+dist/
+build/
+
+# Test artifacts
+test_data/
+*.csv
+!example_input.csv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ optional arguments:
 - Python 3.6 or later
 - No external dependencies (uses only standard library)
 
+## Testing
+
+The project includes comprehensive unit tests covering all functionality.
+
+### Run Tests
+
+```bash
+python3 test_deidentify_zipcode.py
+```
+
+### Test Coverage
+
+The test suite includes 23 tests covering:
+- All precision modes (2-digit, 3-digit, smart)
+- Both fill characters (zeros and X's)
+- All 14 sparsely populated ZIP code prefixes
+- ZIP+4 format handling
+- Edge cases (empty values, leading zeros, whitespace)
+- CSV file processing with single and multiple columns
+- Data integrity and structure preservation
+
+All tests pass successfully.
+
 ## License
 
 This project is released under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,187 @@
-# deidentify-zip-codes
+# ZIP Code Deidentification Tool
+
+A Python script to deidentify ZIP codes in CSV files following HIPAA Safe Harbor guidelines.
+
+## Features
+
+- **Multiple Precision Levels**: Choose between 2-digit, 3-digit, or smart (HIPAA-compliant) precision
+- **Flexible Fill Characters**: Use zeros (0) or X's for replaced digits
+- **HIPAA Safe Harbor Compliance**: Smart mode automatically handles sparsely populated ZIP codes
+- **Multi-Column Support**: Process multiple ZIP code columns in a single pass
+- **ZIP+4 Support**: Handles both 5-digit and ZIP+4 format codes
+
+## Installation
+
+No installation required! This script uses only Python standard library. Just ensure you have Python 3.6 or later:
+
+```bash
+python3 --version
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Default mode (3-digit precision with zeros)
+python3 deidentify_zipcode.py input.csv
+```
+
+This will create `input_deidentified.csv` with ZIP codes converted from `12345` → `12300`.
+
+### Precision Options
+
+```bash
+# 2-digit precision
+python3 deidentify_zipcode.py input.csv -p 2
+# Result: 12345 → 12000
+
+# 3-digit precision (default)
+python3 deidentify_zipcode.py input.csv -p 3
+# Result: 12345 → 12300
+
+# Smart mode (HIPAA-compliant)
+python3 deidentify_zipcode.py input.csv -p smart
+# Result: 12345 → 12300, but 03601 → 03000 (sparse area)
+```
+
+### Fill Character Options
+
+```bash
+# Use X's instead of zeros
+python3 deidentify_zipcode.py input.csv -f X
+# Result: 12345 → 123XX
+
+# Combine with 2-digit precision
+python3 deidentify_zipcode.py input.csv -p 2 -f X
+# Result: 12345 → 12XXX
+```
+
+### Column Selection
+
+```bash
+# Specify column by name
+python3 deidentify_zipcode.py input.csv -c zipcode
+
+# Multiple columns
+python3 deidentify_zipcode.py input.csv -c home_zip work_zip billing_zip
+
+# Use column index (0-based)
+python3 deidentify_zipcode.py input.csv -c 0 3
+```
+
+### Custom Output File
+
+```bash
+python3 deidentify_zipcode.py input.csv -o output.csv
+```
+
+### Complete Example
+
+```bash
+# HIPAA-compliant with X's, multiple columns, custom output
+python3 deidentify_zipcode.py patients.csv \
+  -c home_zipcode work_zipcode \
+  -p smart \
+  -f X \
+  -o patients_deidentified.csv
+```
+
+## HIPAA Safe Harbor Compliance
+
+### What is Smart Mode?
+
+The HIPAA Safe Harbor method requires special handling for sparsely populated areas. According to HIPAA guidelines:
+
+- ZIP codes with 3-digit prefixes representing populations **≥ 20,000**: Keep 3 digits
+- ZIP codes with 3-digit prefixes representing populations **< 20,000**: Keep only 2 digits
+
+### Sparsely Populated ZIP Code Prefixes
+
+Based on 2010 Census data, the following 3-digit prefixes are considered sparsely populated:
+
+```
+036, 059, 102, 203, 205, 369, 556, 692, 821, 823, 878, 879, 884, 893
+```
+
+### Smart Mode Examples
+
+| Original | Smart Mode (zeros) | Smart Mode (X's) | Reason |
+|----------|-------------------|------------------|---------|
+| 12345 | 12300 | 123XX | Normal population |
+| 90210 | 90200 | 902XX | Normal population |
+| 03601 | 03000 | 03XXX | Sparse (prefix 036) |
+| 82101 | 82000 | 82XXX | Sparse (prefix 821) |
+| 89301 | 89000 | 89XXX | Sparse (prefix 893) |
+
+## Examples
+
+See `example_input.csv` for sample data. Try these commands:
+
+```bash
+# Test default mode
+python3 deidentify_zipcode.py example_input.csv -c home_zipcode work_zipcode
+
+# Test smart mode with X's
+python3 deidentify_zipcode.py example_input.csv -c home_zipcode work_zipcode -p smart -f X
+
+# Test 2-digit mode
+python3 deidentify_zipcode.py example_input.csv -c home_zipcode work_zipcode -p 2
+```
+
+## Command-Line Options
+
+```
+usage: deidentify_zipcode.py [-h] [-o OUTPUT] [-c COLUMNS [COLUMNS ...]]
+                             [-p {2,3,smart}] [-f {0,X}]
+                             input_file
+
+positional arguments:
+  input_file            Input CSV file path
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        Output CSV file path (default: adds _deidentified to input filename)
+  -c COLUMNS [COLUMNS ...], --columns COLUMNS [COLUMNS ...]
+                        Column names or indices containing ZIP codes (default: "zipcode")
+  -p {2,3,smart}, --precision {2,3,smart}
+                        Precision level: 2=2-digit, 3=3-digit (default), smart=HIPAA-compliant
+  -f {0,X}, --fill {0,X}
+                        Fill character for replaced digits: 0=zeros (default), X=letter X
+```
+
+## How It Works
+
+1. **Reads CSV file**: Preserves all columns and data structure
+2. **Identifies ZIP code columns**: By name or index
+3. **Deidentifies ZIP codes**:
+   - Extracts digits from ZIP code (handles ZIP+4 format)
+   - Determines precision level (2, 3, or smart)
+   - Replaces trailing digits with fill character
+4. **Writes output**: Creates new CSV file with deidentified data
+
+## Supported Input Formats
+
+- **5-digit ZIP codes**: `12345`
+- **ZIP+4 format**: `12345-6789` (hyphen and extension removed)
+- **Leading zeros**: `00501` (preserved)
+- **Empty values**: Preserved as-is
+
+## Requirements
+
+- Python 3.6 or later
+- No external dependencies (uses only standard library)
+
+## License
+
+This project is released under the MIT License.
+
+## Contributing
+
+Contributions are welcome! Please see REQUIREMENTS.md for detailed specifications.
+
+## References
+
+- [HIPAA Privacy Rule](https://www.hhs.gov/hipaa/for-professionals/privacy/index.html)
+- [HIPAA Safe Harbor De-identification](https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html)

--- a/deidentify_zipcode.py
+++ b/deidentify_zipcode.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Deidentify ZIP codes in CSV files following HIPAA Safe Harbor guidelines.
+
+This script supports multiple precision levels and fill character options
+to accommodate different deidentification requirements.
+"""
+
+import csv
+import re
+import argparse
+from pathlib import Path
+
+
+# Sparsely populated ZIP code prefixes (population < 20,000) based on 2010 Census
+SPARSE_ZIP_PREFIXES = {
+    '036', '059', '102', '203', '205', '369', '556', '692',
+    '821', '823', '878', '879', '884', '893'
+}
+
+
+def deidentify_zipcode(zipcode, precision='3', fill_char='0'):
+    """
+    Deidentify a ZIP code according to specified precision and fill character.
+
+    Args:
+        zipcode: ZIP code as string or number (5-digit or ZIP+4 format)
+        precision: '2', '3', or 'smart' for precision level
+        fill_char: '0' or 'X' for fill character
+
+    Returns:
+        Deidentified ZIP code string
+    """
+    if not zipcode:
+        return zipcode
+
+    # Convert to string and remove any whitespace
+    zipcode_str = str(zipcode).strip()
+
+    # Extract digits only (handles ZIP+4 format like '12345-6789')
+    digits = re.sub(r'[^\d]', '', zipcode_str)
+
+    # If less than required digits, return as-is
+    if len(digits) < 2:
+        return zipcode_str
+
+    # Determine precision level
+    if precision == 'smart':
+        # Check if this is a sparsely populated ZIP code prefix
+        if len(digits) >= 3 and digits[:3] in SPARSE_ZIP_PREFIXES:
+            actual_precision = 2
+        else:
+            actual_precision = 3
+    else:
+        actual_precision = int(precision)
+
+    # Ensure we have enough digits
+    if len(digits) < actual_precision:
+        actual_precision = len(digits)
+
+    # Build deidentified ZIP code
+    kept_digits = digits[:actual_precision]
+    fill_count = 5 - actual_precision
+
+    return kept_digits + (fill_char * fill_count)
+
+
+def deidentify_csv(input_file, output_file, zipcode_columns, precision='3', fill_char='0'):
+    """
+    Deidentify ZIP codes in a CSV file.
+
+    Args:
+        input_file: Path to input CSV file
+        output_file: Path to output CSV file
+        zipcode_columns: List of column names or indices containing ZIP codes
+        precision: '2', '3', or 'smart' for precision level
+        fill_char: '0' or 'X' for fill character
+    """
+    with open(input_file, 'r', newline='', encoding='utf-8') as infile:
+        reader = csv.DictReader(infile)
+
+        if not reader.fieldnames:
+            raise ValueError("CSV file appears to be empty or malformed")
+
+        # Determine which columns to deidentify
+        columns_to_process = []
+        for col in zipcode_columns:
+            if isinstance(col, int):
+                # Column index
+                if 0 <= col < len(reader.fieldnames):
+                    columns_to_process.append(reader.fieldnames[col])
+                else:
+                    print(f"Warning: Column index {col} out of range (max: {len(reader.fieldnames)-1})")
+            else:
+                # Column name
+                if col in reader.fieldnames:
+                    columns_to_process.append(col)
+                else:
+                    print(f"Warning: Column '{col}' not found in CSV")
+
+        if not columns_to_process:
+            raise ValueError("No valid ZIP code columns found")
+
+        # Process the CSV
+        rows = []
+        for row in reader:
+            for col in columns_to_process:
+                if col in row:
+                    row[col] = deidentify_zipcode(row[col], precision, fill_char)
+            rows.append(row)
+
+        # Write output
+        with open(output_file, 'w', newline='', encoding='utf-8') as outfile:
+            writer = csv.DictWriter(outfile, fieldnames=reader.fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        print(f"Processed {len(rows)} rows")
+        print(f"Deidentified columns: {', '.join(columns_to_process)}")
+        print(f"Precision: {precision}, Fill character: {fill_char}")
+        print(f"Output saved to: {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Deidentify ZIP codes in CSV files following HIPAA Safe Harbor guidelines',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic usage (3-digit precision with zeros)
+  %(prog)s input.csv
+
+  # Use X's instead of zeros
+  %(prog)s input.csv -f X
+
+  # 2-digit precision
+  %(prog)s input.csv -p 2
+
+  # HIPAA-compliant smart mode
+  %(prog)s input.csv -p smart -f X
+
+  # Multiple columns
+  %(prog)s input.csv -c home_zip work_zip billing_zip
+        """
+    )
+    parser.add_argument(
+        'input_file',
+        help='Input CSV file path'
+    )
+    parser.add_argument(
+        '-o', '--output',
+        help='Output CSV file path (default: adds _deidentified to input filename)',
+        default=None
+    )
+    parser.add_argument(
+        '-c', '--columns',
+        nargs='+',
+        help='Column names or indices containing ZIP codes (default: "zipcode")',
+        default=['zipcode']
+    )
+    parser.add_argument(
+        '-p', '--precision',
+        choices=['2', '3', 'smart'],
+        default='3',
+        help='Precision level: 2=2-digit, 3=3-digit (default), smart=HIPAA-compliant (3-digit for normal, 2-digit for sparse areas)'
+    )
+    parser.add_argument(
+        '-f', '--fill',
+        choices=['0', 'X'],
+        default='0',
+        help='Fill character for replaced digits: 0=zeros (default), X=letter X'
+    )
+
+    args = parser.parse_args()
+
+    # Validate input file exists
+    if not Path(args.input_file).exists():
+        parser.error(f"Input file not found: {args.input_file}")
+
+    # Set default output filename
+    if args.output is None:
+        input_path = Path(args.input_file)
+        args.output = input_path.parent / f"{input_path.stem}_deidentified{input_path.suffix}"
+
+    # Convert column indices if they're numbers
+    columns = []
+    for col in args.columns:
+        try:
+            columns.append(int(col))
+        except ValueError:
+            columns.append(col)
+
+    # Process the CSV file
+    try:
+        deidentify_csv(args.input_file, args.output, columns, args.precision, args.fill)
+    except Exception as e:
+        parser.error(f"Error processing CSV: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/example_input.csv
+++ b/example_input.csv
@@ -1,0 +1,9 @@
+patient_id,name,home_zipcode,work_zipcode,age
+1001,John Doe,12345,90210,45
+1002,Jane Smith,03601,02101,32
+1003,Bob Johnson,82101,10234,58
+1004,Alice Williams,94102,60601,41
+1005,Charlie Brown,05901,12345-6789,29
+1006,Diana Prince,89301,33101,37
+1007,Eve Davis,10001,78701,51
+1008,Frank Miller,02134,85001,44

--- a/test_deidentify_zipcode.py
+++ b/test_deidentify_zipcode.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Unit tests for deidentify_zipcode.py
+
+Run with: python3 test_deidentify_zipcode.py
+"""
+
+import unittest
+import csv
+import os
+from pathlib import Path
+from deidentify_zipcode import deidentify_zipcode, deidentify_csv, SPARSE_ZIP_PREFIXES
+
+
+class TestDeidentifyZipcode(unittest.TestCase):
+    """Test cases for ZIP code deidentification functions"""
+
+    def test_3digit_zeros_normal(self):
+        """Test 3-digit precision with zeros for normal ZIP codes"""
+        self.assertEqual(deidentify_zipcode('12345', '3', '0'), '12300')
+        self.assertEqual(deidentify_zipcode('90210', '3', '0'), '90200')
+        self.assertEqual(deidentify_zipcode('00501', '3', '0'), '00500')
+
+    def test_3digit_x_normal(self):
+        """Test 3-digit precision with X's for normal ZIP codes"""
+        self.assertEqual(deidentify_zipcode('12345', '3', 'X'), '123XX')
+        self.assertEqual(deidentify_zipcode('90210', '3', 'X'), '902XX')
+        self.assertEqual(deidentify_zipcode('00501', '3', 'X'), '005XX')
+
+    def test_2digit_zeros(self):
+        """Test 2-digit precision with zeros"""
+        self.assertEqual(deidentify_zipcode('12345', '2', '0'), '12000')
+        self.assertEqual(deidentify_zipcode('90210', '2', '0'), '90000')
+        self.assertEqual(deidentify_zipcode('00501', '2', '0'), '00000')
+
+    def test_2digit_x(self):
+        """Test 2-digit precision with X's"""
+        self.assertEqual(deidentify_zipcode('12345', '2', 'X'), '12XXX')
+        self.assertEqual(deidentify_zipcode('90210', '2', 'X'), '90XXX')
+        self.assertEqual(deidentify_zipcode('00501', '2', 'X'), '00XXX')
+
+    def test_smart_mode_normal_zeros(self):
+        """Test smart mode with zeros for normal population ZIP codes"""
+        self.assertEqual(deidentify_zipcode('12345', 'smart', '0'), '12300')
+        self.assertEqual(deidentify_zipcode('90210', 'smart', '0'), '90200')
+        self.assertEqual(deidentify_zipcode('94102', 'smart', '0'), '94100')
+
+    def test_smart_mode_normal_x(self):
+        """Test smart mode with X's for normal population ZIP codes"""
+        self.assertEqual(deidentify_zipcode('12345', 'smart', 'X'), '123XX')
+        self.assertEqual(deidentify_zipcode('90210', 'smart', 'X'), '902XX')
+        self.assertEqual(deidentify_zipcode('94102', 'smart', 'X'), '941XX')
+
+    def test_smart_mode_sparse_zeros(self):
+        """Test smart mode with zeros for sparsely populated ZIP codes"""
+        # Test all sparse prefixes
+        self.assertEqual(deidentify_zipcode('03601', 'smart', '0'), '03000')  # 036
+        self.assertEqual(deidentify_zipcode('05901', 'smart', '0'), '05000')  # 059
+        self.assertEqual(deidentify_zipcode('10234', 'smart', '0'), '10000')  # 102
+        self.assertEqual(deidentify_zipcode('20301', 'smart', '0'), '20000')  # 203
+        self.assertEqual(deidentify_zipcode('20501', 'smart', '0'), '20000')  # 205
+        self.assertEqual(deidentify_zipcode('36901', 'smart', '0'), '36000')  # 369
+        self.assertEqual(deidentify_zipcode('55601', 'smart', '0'), '55000')  # 556
+        self.assertEqual(deidentify_zipcode('69201', 'smart', '0'), '69000')  # 692
+        self.assertEqual(deidentify_zipcode('82101', 'smart', '0'), '82000')  # 821
+        self.assertEqual(deidentify_zipcode('82301', 'smart', '0'), '82000')  # 823
+        self.assertEqual(deidentify_zipcode('87801', 'smart', '0'), '87000')  # 878
+        self.assertEqual(deidentify_zipcode('87901', 'smart', '0'), '87000')  # 879
+        self.assertEqual(deidentify_zipcode('88401', 'smart', '0'), '88000')  # 884
+        self.assertEqual(deidentify_zipcode('89301', 'smart', '0'), '89000')  # 893
+
+    def test_smart_mode_sparse_x(self):
+        """Test smart mode with X's for sparsely populated ZIP codes"""
+        self.assertEqual(deidentify_zipcode('03601', 'smart', 'X'), '03XXX')  # 036
+        self.assertEqual(deidentify_zipcode('05901', 'smart', 'X'), '05XXX')  # 059
+        self.assertEqual(deidentify_zipcode('10234', 'smart', 'X'), '10XXX')  # 102
+        self.assertEqual(deidentify_zipcode('82101', 'smart', 'X'), '82XXX')  # 821
+        self.assertEqual(deidentify_zipcode('89301', 'smart', 'X'), '89XXX')  # 893
+
+    def test_zip_plus_4_format(self):
+        """Test ZIP+4 format handling"""
+        self.assertEqual(deidentify_zipcode('12345-6789', '3', '0'), '12300')
+        self.assertEqual(deidentify_zipcode('12345-6789', '3', 'X'), '123XX')
+        self.assertEqual(deidentify_zipcode('12345-6789', '2', '0'), '12000')
+        self.assertEqual(deidentify_zipcode('03601-1234', 'smart', '0'), '03000')
+        self.assertEqual(deidentify_zipcode('03601-1234', 'smart', 'X'), '03XXX')
+
+    def test_empty_values(self):
+        """Test handling of empty/null values"""
+        self.assertEqual(deidentify_zipcode('', '3', '0'), '')
+        self.assertEqual(deidentify_zipcode(None, '3', '0'), None)
+        # Whitespace-only strings are stripped to empty
+        self.assertEqual(deidentify_zipcode('   ', '3', '0'), '')
+
+    def test_short_zipcodes(self):
+        """Test handling of ZIP codes with less than required digits"""
+        # Less than 2 digits - should return as-is
+        self.assertEqual(deidentify_zipcode('1', '3', '0'), '1')
+        self.assertEqual(deidentify_zipcode('', '3', '0'), '')
+
+        # Exactly 2 digits with 2-digit precision
+        self.assertEqual(deidentify_zipcode('12', '2', '0'), '12000')
+
+        # 2 digits with 3-digit precision (fallback to 2-digit)
+        self.assertEqual(deidentify_zipcode('12', '3', '0'), '12000')
+
+    def test_numeric_input(self):
+        """Test handling of numeric ZIP codes (not strings)"""
+        self.assertEqual(deidentify_zipcode(12345, '3', '0'), '12300')
+        self.assertEqual(deidentify_zipcode(501, '3', '0'), '50100')
+        self.assertEqual(deidentify_zipcode(12345, 'smart', 'X'), '123XX')
+
+    def test_whitespace_handling(self):
+        """Test handling of ZIP codes with whitespace"""
+        self.assertEqual(deidentify_zipcode(' 12345 ', '3', '0'), '12300')
+        self.assertEqual(deidentify_zipcode('12345 ', '3', 'X'), '123XX')
+
+    def test_all_sparse_prefixes_defined(self):
+        """Verify all sparse prefixes are correctly defined"""
+        expected_sparse = {'036', '059', '102', '203', '205', '369',
+                          '556', '692', '821', '823', '878', '879',
+                          '884', '893'}
+        self.assertEqual(SPARSE_ZIP_PREFIXES, expected_sparse)
+
+
+class TestDeidentifyCSV(unittest.TestCase):
+    """Test cases for CSV file processing"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_dir = Path('test_data')
+        self.test_dir.mkdir(exist_ok=True)
+
+        # Create test CSV
+        self.test_input = self.test_dir / 'test_input.csv'
+        self.test_output = self.test_dir / 'test_output.csv'
+
+        with open(self.test_input, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['id', 'name', 'zipcode', 'work_zip'])
+            writer.writerow(['1', 'Alice', '12345', '90210'])
+            writer.writerow(['2', 'Bob', '03601', '82101'])
+            writer.writerow(['3', 'Charlie', '94102-5678', '00501'])
+
+    def tearDown(self):
+        """Clean up test files"""
+        if self.test_input.exists():
+            self.test_input.unlink()
+        if self.test_output.exists():
+            self.test_output.unlink()
+        if self.test_dir.exists():
+            self.test_dir.rmdir()
+
+    def test_csv_single_column_default(self):
+        """Test CSV processing with single column and default settings"""
+        deidentify_csv(self.test_input, self.test_output, ['zipcode'])
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        self.assertEqual(rows[0]['zipcode'], '12300')
+        self.assertEqual(rows[1]['zipcode'], '03600')
+        self.assertEqual(rows[2]['zipcode'], '94100')
+
+        # Work_zip should be unchanged
+        self.assertEqual(rows[0]['work_zip'], '90210')
+
+    def test_csv_multiple_columns(self):
+        """Test CSV processing with multiple columns"""
+        deidentify_csv(self.test_input, self.test_output,
+                      ['zipcode', 'work_zip'], '3', 'X')
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        self.assertEqual(rows[0]['zipcode'], '123XX')
+        self.assertEqual(rows[0]['work_zip'], '902XX')
+        self.assertEqual(rows[1]['zipcode'], '036XX')
+        self.assertEqual(rows[1]['work_zip'], '821XX')
+
+    def test_csv_smart_mode(self):
+        """Test CSV processing with smart mode"""
+        deidentify_csv(self.test_input, self.test_output,
+                      ['zipcode', 'work_zip'], 'smart', '0')
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        # Normal population ZIP
+        self.assertEqual(rows[0]['zipcode'], '12300')
+        self.assertEqual(rows[0]['work_zip'], '90200')
+
+        # Sparse population ZIPs
+        self.assertEqual(rows[1]['zipcode'], '03000')
+        self.assertEqual(rows[1]['work_zip'], '82000')
+
+        # Normal population ZIP with ZIP+4
+        self.assertEqual(rows[2]['zipcode'], '94100')
+
+    def test_csv_column_by_index(self):
+        """Test CSV processing using column indices"""
+        deidentify_csv(self.test_input, self.test_output, [2, 3], '2', '0')
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        self.assertEqual(rows[0]['zipcode'], '12000')
+        self.assertEqual(rows[0]['work_zip'], '90000')
+
+    def test_csv_preserves_other_columns(self):
+        """Test that CSV processing preserves non-ZIP columns"""
+        deidentify_csv(self.test_input, self.test_output, ['zipcode'])
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        # Check other columns are unchanged
+        self.assertEqual(rows[0]['id'], '1')
+        self.assertEqual(rows[0]['name'], 'Alice')
+        self.assertEqual(rows[1]['id'], '2')
+        self.assertEqual(rows[1]['name'], 'Bob')
+
+    def test_csv_preserves_structure(self):
+        """Test that CSV structure (headers, row count) is preserved"""
+        deidentify_csv(self.test_input, self.test_output, ['zipcode'])
+
+        with open(self.test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(list(rows[0].keys()), ['id', 'name', 'zipcode', 'work_zip'])
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Test edge cases and error handling"""
+
+    def test_leading_zeros_preserved(self):
+        """Test that leading zeros are preserved in output"""
+        self.assertEqual(deidentify_zipcode('00501', '3', '0'), '00500')
+        self.assertEqual(deidentify_zipcode('00501', '3', 'X'), '005XX')
+        self.assertEqual(deidentify_zipcode('00501', '2', '0'), '00000')
+
+    def test_special_sparse_cases(self):
+        """Test edge cases for sparse ZIP detection"""
+        # 102 is sparse
+        self.assertEqual(deidentify_zipcode('10234', 'smart', '0'), '10000')
+
+        # 101 is NOT sparse (should use 3-digit)
+        self.assertEqual(deidentify_zipcode('10134', 'smart', '0'), '10100')
+
+        # 036 is sparse
+        self.assertEqual(deidentify_zipcode('03601', 'smart', '0'), '03000')
+
+        # 037 is NOT sparse (should use 3-digit)
+        self.assertEqual(deidentify_zipcode('03701', 'smart', '0'), '03700')
+
+    def test_boundary_cases(self):
+        """Test boundary cases for ZIP codes"""
+        # Minimum valid 5-digit ZIP
+        self.assertEqual(deidentify_zipcode('00001', '3', '0'), '00000')
+
+        # Maximum valid 5-digit ZIP
+        self.assertEqual(deidentify_zipcode('99950', '3', '0'), '99900')
+
+
+def run_tests():
+    """Run all tests"""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    suite.addTests(loader.loadTestsFromTestCase(TestDeidentifyZipcode))
+    suite.addTests(loader.loadTestsFromTestCase(TestDeidentifyCSV))
+    suite.addTests(loader.loadTestsFromTestCase(TestEdgeCases))
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    return result.wasSuccessful()
+
+
+if __name__ == '__main__':
+    import sys
+    success = run_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
Complete implementation of ZIP code deidentification script with HIPAA Safe Harbor compliance.

## Changes

### New Files
- **deidentify_zipcode.py**: Main script with full functionality
  - Configurable precision levels (2, 3, smart)
  - Configurable fill characters (0 or X)
  - HIPAA Safe Harbor smart mode
  - Multi-column support
  - ZIP+4 format handling
- **example_input.csv**: Test data with various ZIP codes including sparse areas
- **README.md**: Comprehensive documentation (updated)

### Features Implemented
- ✅ 2-digit precision mode
- ✅ 3-digit precision mode (default)
- ✅ Smart mode (HIPAA-compliant)
  - Uses 3-digit for normal populations (≥20,000)
  - Uses 2-digit for sparse populations (<20,000)
- ✅ Fill character options (zeros or X's)
- ✅ Multiple column processing
- ✅ Column selection by name or index
- ✅ ZIP+4 format support
- ✅ Custom output file path
- ✅ Comprehensive error handling

## Test Results

All modes tested successfully:

| Mode | Input | Output | Status |
|------|-------|--------|--------|
| Default (3-digit, 0) | 12345 | 12300 | ✅ |
| 2-digit, 0 | 12345 | 12000 | ✅ |
| 3-digit, X | 12345 | 123XX | ✅ |
| Smart, 0 (normal) | 12345 | 12300 | ✅ |
| Smart, 0 (sparse) | 03601 | 03000 | ✅ |
| Smart, X (normal) | 12345 | 123XX | ✅ |
| Smart, X (sparse) | 82101 | 82XXX | ✅ |

## HIPAA Compliance
Smart mode correctly identifies and handles all 14 sparsely populated ZIP code prefixes:
`036, 059, 102, 203, 205, 369, 556, 692, 821, 823, 878, 879, 884, 893`

## Documentation
- README includes installation, usage, examples, and HIPAA compliance information
- Comprehensive command-line help with examples
- Clear error messages for invalid inputs

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)