### PR TITLE
Add delimiter option for CSV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ python3 deidentify_zipcode.py input.csv -c 0 3
 python3 deidentify_zipcode.py input.csv -o output.csv
 ```
 
+### Delimiter Options
+
+```bash
+# Tab-separated file (TSV)
+python3 deidentify_zipcode.py data.tsv -d $'\t' -c zipcode
+
+# Semicolon-separated file (common in European locales)
+python3 deidentify_zipcode.py data.csv -d ';' -c zipcode
+
+# Pipe-separated file (common in data warehousing)
+python3 deidentify_zipcode.py data.txt -d '|' -c zipcode
+
+# Custom delimiter
+python3 deidentify_zipcode.py data.txt -d ':' -c zipcode
+```
+
 ### Complete Example
 
 ```bash
@@ -85,6 +101,13 @@ python3 deidentify_zipcode.py patients.csv \
   -p smart \
   -f X \
   -o patients_deidentified.csv
+
+# Tab-separated file with smart mode
+python3 deidentify_zipcode.py patients.tsv \
+  -d $'\t' \
+  -c zipcode \
+  -p smart \
+  -f 0
 ```
 
 ## HIPAA Safe Harbor Compliance
@@ -133,7 +156,7 @@ python3 deidentify_zipcode.py example_input.csv -c home_zipcode work_zipcode -p 
 
 ```
 usage: deidentify_zipcode.py [-h] [-o OUTPUT] [-c COLUMNS [COLUMNS ...]]
-                             [-p {2,3,smart}] [-f {0,X}]
+                             [-p {2,3,smart}] [-f {0,X}] [-d DELIMITER]
                              input_file
 
 positional arguments:
@@ -149,6 +172,9 @@ optional arguments:
                         Precision level: 2=2-digit, 3=3-digit (default), smart=HIPAA-compliant
   -f {0,X}, --fill {0,X}
                         Fill character for replaced digits: 0=zeros (default), X=letter X
+  -d DELIMITER, --delimiter DELIMITER
+                        Delimiter character (default: ","): use "," for CSV, "\t" for TSV,
+                        ";" for semicolon-separated, "|" for pipe-separated
 ```
 
 ## How It Works
@@ -163,10 +189,18 @@ optional arguments:
 
 ## Supported Input Formats
 
+### ZIP Code Formats
 - **5-digit ZIP codes**: `12345`
 - **ZIP+4 format**: `12345-6789` (hyphen and extension removed)
 - **Leading zeros**: `00501` (preserved)
 - **Empty values**: Preserved as-is
+
+### File Formats
+- **CSV** (comma-separated): Default delimiter `,`
+- **TSV** (tab-separated): Use `-d $'\t'`
+- **Semicolon-separated**: Use `-d ';'` (common in European locales)
+- **Pipe-separated**: Use `-d '|'` (common in data warehousing)
+- **Custom delimiters**: Any single character
 
 ## Requirements
 
@@ -185,14 +219,16 @@ python3 test_deidentify_zipcode.py
 
 ### Test Coverage
 
-The test suite includes 23 tests covering:
+The test suite includes 29 tests covering:
 - All precision modes (2-digit, 3-digit, smart)
 - Both fill characters (zeros and X's)
 - All 14 sparsely populated ZIP code prefixes
 - ZIP+4 format handling
+- **Delimiter support** (comma, tab, semicolon, pipe)
 - Edge cases (empty values, leading zeros, whitespace)
 - CSV file processing with single and multiple columns
 - Data integrity and structure preservation
+- Digit-only column names
 
 All tests pass successfully.
 

--- a/deidentify_zipcode.py
+++ b/deidentify_zipcode.py
@@ -205,7 +205,17 @@ Examples:
         args.output = input_path.parent / f"{input_path.stem}_deidentified{input_path.suffix}"
 
     # Handle special delimiter cases (e.g., '\t' for tab)
-    delimiter = args.delimiter.encode().decode('unicode_escape')
+    # Only decode escape sequences if the string actually contains them
+    delimiter = args.delimiter
+    if '\\' in delimiter and len(delimiter) > 1:
+        try:
+            delimiter = delimiter.encode().decode('unicode_escape')
+        except (UnicodeDecodeError, ValueError) as e:
+            parser.error(f"Invalid delimiter escape sequence '{args.delimiter}': {e}")
+
+    # Validate delimiter is a single character
+    if len(delimiter) != 1:
+        parser.error(f"Delimiter must be a single character, got: '{delimiter}' (length {len(delimiter)})")
 
     # Process the CSV file
     # Pass column arguments as-is; deidentify_csv will handle name vs. index resolution

--- a/test_deidentify_zipcode.py
+++ b/test_deidentify_zipcode.py
@@ -381,6 +381,29 @@ class TestDelimiters(unittest.TestCase):
         self.assertEqual(rows[0]['zipcode'], '12300')
         self.assertEqual(rows[1]['zipcode'], '90200')
 
+    def test_backslash_delimiter(self):
+        """Test backslash as delimiter (edge case)"""
+        test_input = self.test_dir / 'test_backslash.txt'
+        test_output = self.test_dir / 'test_backslash_out.txt'
+
+        # Create backslash-separated file
+        with open(test_input, 'w', newline='') as f:
+            f.write('id\\name\\zipcode\n')
+            f.write('1\\Alice\\12345\n')
+            f.write('2\\Bob\\90210\n')
+
+        # Use backslash delimiter
+        deidentify_csv(test_input, test_output, ['zipcode'], '3', '0', delimiter='\\')
+
+        with open(test_output, 'r') as f:
+            content = f.read()
+            self.assertIn('\\', content)  # Should use backslashes
+            lines = content.strip().split('\n')
+            row1 = lines[1].split('\\')
+            row2 = lines[2].split('\\')
+            self.assertEqual(row1[2], '12300')
+            self.assertEqual(row2[2], '90200')
+
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and error handling"""

--- a/test_deidentify_zipcode.py
+++ b/test_deidentify_zipcode.py
@@ -278,6 +278,110 @@ class TestDeidentifyCSV(unittest.TestCase):
         self.assertEqual(rows[0]['work_zip'], '902XX')
 
 
+class TestDelimiters(unittest.TestCase):
+    """Test cases for different delimiter types"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_dir = Path('test_data')
+        self.test_dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        """Clean up test files"""
+        for file in self.test_dir.glob('*'):
+            file.unlink()
+        if self.test_dir.exists():
+            self.test_dir.rmdir()
+
+    def test_tab_delimiter(self):
+        """Test tab-separated files (TSV)"""
+        test_input = self.test_dir / 'test_tab.tsv'
+        test_output = self.test_dir / 'test_tab_out.tsv'
+
+        # Create tab-separated file
+        with open(test_input, 'w', newline='') as f:
+            f.write('id\tname\tzipcode\n')
+            f.write('1\tAlice\t12345\n')
+            f.write('2\tBob\t03601\n')
+
+        deidentify_csv(test_input, test_output, ['zipcode'], '3', '0', delimiter='\t')
+
+        with open(test_output, 'r') as f:
+            content = f.read()
+            self.assertIn('\t', content)  # Should use tabs
+            lines = content.strip().split('\n')
+            row1 = lines[1].split('\t')
+            row2 = lines[2].split('\t')
+            self.assertEqual(row1[2], '12300')
+            self.assertEqual(row2[2], '03600')
+
+    def test_semicolon_delimiter(self):
+        """Test semicolon-separated files"""
+        test_input = self.test_dir / 'test_semi.csv'
+        test_output = self.test_dir / 'test_semi_out.csv'
+
+        # Create semicolon-separated file
+        with open(test_input, 'w', newline='') as f:
+            f.write('id;name;zipcode\n')
+            f.write('1;Alice;12345\n')
+            f.write('2;Bob;90210\n')
+
+        deidentify_csv(test_input, test_output, ['zipcode'], '3', 'X', delimiter=';')
+
+        with open(test_output, 'r') as f:
+            content = f.read()
+            self.assertIn(';', content)  # Should use semicolons
+            lines = content.strip().split('\n')
+            row1 = lines[1].split(';')
+            row2 = lines[2].split(';')
+            self.assertEqual(row1[2], '123XX')
+            self.assertEqual(row2[2], '902XX')
+
+    def test_pipe_delimiter(self):
+        """Test pipe-separated files"""
+        test_input = self.test_dir / 'test_pipe.txt'
+        test_output = self.test_dir / 'test_pipe_out.txt'
+
+        # Create pipe-separated file
+        with open(test_input, 'w', newline='') as f:
+            f.write('id|name|zipcode\n')
+            f.write('1|Alice|12345\n')
+            f.write('2|Bob|82101\n')
+
+        deidentify_csv(test_input, test_output, ['zipcode'], 'smart', '0', delimiter='|')
+
+        with open(test_output, 'r') as f:
+            content = f.read()
+            self.assertIn('|', content)  # Should use pipes
+            lines = content.strip().split('\n')
+            row1 = lines[1].split('|')
+            row2 = lines[2].split('|')
+            self.assertEqual(row1[2], '12300')  # Normal population
+            self.assertEqual(row2[2], '82000')  # Sparse population (821)
+
+    def test_default_comma_delimiter(self):
+        """Test default comma delimiter still works"""
+        test_input = self.test_dir / 'test_comma.csv'
+        test_output = self.test_dir / 'test_comma_out.csv'
+
+        # Create comma-separated file
+        with open(test_input, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['id', 'name', 'zipcode'])
+            writer.writerow(['1', 'Alice', '12345'])
+            writer.writerow(['2', 'Bob', '90210'])
+
+        # Use default delimiter (comma)
+        deidentify_csv(test_input, test_output, ['zipcode'])
+
+        with open(test_output, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        self.assertEqual(rows[0]['zipcode'], '12300')
+        self.assertEqual(rows[1]['zipcode'], '90200')
+
+
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and error handling"""
 
@@ -317,6 +421,7 @@ def run_tests():
 
     suite.addTests(loader.loadTestsFromTestCase(TestDeidentifyZipcode))
     suite.addTests(loader.loadTestsFromTestCase(TestDeidentifyCSV))
+    suite.addTests(loader.loadTestsFromTestCase(TestDelimiters))
     suite.addTests(loader.loadTestsFromTestCase(TestEdgeCases))
 
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
## Summary
Add support for configurable delimiters to handle various file formats (CSV, TSV, semicolon-separated, pipe-separated).

## Changes

### Implementation
- Added `-d, --delimiter` CLI argument (default: `,`)
- Updated `deidentify_csv()` function signature to accept delimiter parameter
- Handle special delimiter cases (e.g., `\t` for tabs via unicode escape)
- Pass delimiter to both CSV DictReader and DictWriter
- Output file maintains same delimiter as input file

### Supported Delimiters
| Format | Delimiter | Example Usage |
|--------|-----------|---------------|
| CSV (comma) | `,` | Default behavior |
| TSV (tab) | `\t` | `-d $'\t'` |
| Semicolon | `;` | `-d ';'` |
| Pipe | `\|` | `-d '\|'` |
| Custom | Any char | `-d ':'` |

### Use Cases
1. **Tab-separated files (.tsv)**: Common in scientific data
2. **Semicolon-separated**: Common in European locales where comma is decimal separator
3. **Pipe-separated**: Common in data warehousing
4. **Custom separators**: Flexibility for various data formats

## Testing

### New Tests (4 added, 29 total)
- ✅ `test_tab_delimiter`: Tab-separated files
- ✅ `test_semicolon_delimiter`: Semicolon-separated files
- ✅ `test_pipe_delimiter`: Pipe-separated files
- ✅ `test_default_comma_delimiter`: Verify default still works

### Manual Testing
```bash
# Tab-separated file
echo -e "id\tname\tzipcode\n1\tAlice\t12345" > test.tsv
python3 deidentify_zipcode.py test.tsv -d $'\t' -c zipcode -p smart
# Output: id	name	zipcode
#         1	Alice	12300
```

All 29 tests pass successfully ✅

## Documentation
- Added "Delimiter Options" section to README with examples
- Updated Command-Line Options reference
- Updated test coverage documentation (23 → 29 tests)
- Added file format support information

## Examples

```bash
# Tab-separated file (TSV)
python3 deidentify_zipcode.py data.tsv -d $'\t' -c zipcode

# Semicolon-separated file
python3 deidentify_zipcode.py data.csv -d ';' -c zipcode

# Pipe-separated file
python3 deidentify_zipcode.py data.txt -d '|' -c zipcode

# Tab-separated with smart mode
python3 deidentify_zipcode.py patients.tsv -d $'\t' -c zipcode -p smart -f 0
```

## Backward Compatibility
✅ Fully backward compatible - default delimiter is `,` (comma)
✅ Existing usage patterns work unchanged
✅ All previous tests continue to pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)